### PR TITLE
refactor msg_id

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -72,10 +72,7 @@ impl Node {
                     .expect("should be able to recv on one of the broadcast responses")
             });
 
-            let new_msg_id = self.clone().reserve_next_msg_id();
-
-            let mut body = body.clone();
-            self.clone().send(destination, body, Some(tx)).await;
+            self.clone().send(destination, body.clone(), Some(tx)).await;
         }
 
         tokio::spawn(async move {


### PR DESCRIPTION
Remove msg_id from the Body enum and introduce a wrapper type BodyWithMsgId. Send requires just a Body and creates a BodyWithId automatically. When handling messages, we receive a BodyWithMsgId, so we can use the msg_id to populate the in_reply_to field